### PR TITLE
Improve id generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ start-debug:
 	@bash -c 'go build . && DEBUG=true java -jar server.jar -l $(LEVEL) -c "./dtu-ai-mas-final-assignment" -g'
 
 profile:
-	@bash -c 'go build . && java -jar server.jar -l $(LEVEL) -c "./dtu-ai-mas-final-assignment -cpuprofile cpu.prof"'
+	@bash -c 'go build . && java -jar server.jar -l $(LEVEL) -c "./dtu-ai-mas-final-assignment -cpuprofile cpu.prof -memprofile mem.prof"'
 
 debug:
 	@bash -c "dlv attach --api-version 2 --headless --listen=:2345 `pgrep dtu-ai-mas-final-assignment` ./dtu-ai-mas-final-assignment"

--- a/config/config.go
+++ b/config/config.go
@@ -18,4 +18,7 @@ const (
 	WallsSymbol      = '+'
 	FreeSpaceSymbol  = ' '
 	ServersTrueValue = "true"
+
+	BytesUsedForEachPoint      = 4                         // Each point is turned into a uint32 which consumes 4 bytes
+	BytesUsedForEachAgentOrBox = BytesUsedForEachPoint * 2 // We have 2 points
 )

--- a/level/level.go
+++ b/level/level.go
@@ -24,13 +24,14 @@ type (
 	Info struct {
 		LevelInfo              map[string]string
 		GoalCount              int
-		AgentColor             SimpleMap
-		BoxColor               SimpleMap
+		BytesUsedForBoxes      int
+		TotalBytesForID        int
+		BoxColor, AgentColor   SimpleMap
 		MaxCoord               Coordinates
 		WallsCoordinates       CoordinatesLookup
+		BoxGoalAssignment      []Coordinates
 		InGameWallsCoordinates []Coordinates
 		GoalCoordinates        IntrestingCoordinates
-		BoxGoalAssignment      []Coordinates
 	}
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -165,6 +165,10 @@ func preproccessLvl(levelInfo *level.Info, state *level.CurrentState) {
 
 	wg.Wait()
 
+	// Count bytes in ID used for boxes
+	levelInfo.BytesUsedForBoxes = (len(state.Boxes) * config.BytesUsedForEachAgentOrBox) + 1
+	// Count total bytes used for each ID
+	levelInfo.TotalBytesForID = levelInfo.BytesUsedForBoxes + len(state.Agents)*config.BytesUsedForEachAgentOrBox + 1
 	levelInfo.GoalCount = goalCount
 	levelInfo.InGameWallsCoordinates = inGameWalls
 	levelInfo.BoxGoalAssignment = boxGoalAssignment


### PR DESCRIPTION
Current memory object allocations for id generation (testing on MAaicecubes.lvl)

<img width="898" alt="Screenshot 2020-06-03 at 21 46 50" src="https://user-images.githubusercontent.com/8433031/83685030-419c9d00-a5e8-11ea-89d1-31eb9c6f8c39.png">

Memory object allocations used from this branch:

![Screenshot 2020-06-03 at 22 09 52](https://user-images.githubusercontent.com/8433031/83685501-123a6000-a5e9-11ea-9c48-098609c9c81e.png)


> Note: Without using the unsafe conversion bytes to string we had the following object allocations:
<img width="478" alt="Screenshot 2020-06-03 at 21 47 03" src="https://user-images.githubusercontent.com/8433031/83685611-35fda600-a5e9-11ea-987a-de94c3789a79.png">
